### PR TITLE
perf(ci): cross-compile Go images for arm64 and drop BUILD_DATE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,11 +197,10 @@ jobs:
             echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Read version and build date
+      - name: Read version
         id: version
         run: |
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       # Push :<sha> only on main. On PRs, load the (single-arch) image into the
       # local daemon so the Trivy step below can scan it without a registry push.
@@ -216,7 +215,6 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             GIT_SHA=${{ github.sha }}
-            BUILD_DATE=${{ steps.version.outputs.build_date }}
           tags: gprins/${{ matrix.image.name }}:${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# The main Build image to build all our binaries
-FROM golang:1.26.5-alpine AS build
+# The main Build image to build all our binaries.
+# Pinned to the native build platform so Go cross-compiles to the target arch
+# (GOARCH below) instead of running under QEMU emulation on the arm64 leg.
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS build
 
 WORKDIR /
 ENV CGO_ENABLED=0
@@ -62,13 +64,13 @@ RUN if [ "$SKIP_SWAG" = "true" ]; then \
 WORKDIR /
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    go build -tags dynamic -ldflags="-s -w \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags dynamic -ldflags="-s -w \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
       -o ryAdminAPI ./cmd/api/ry-admin
 # RUN upx --brute /ryAdminAPI # This takes a very long time to compress the binary we should only use if for official releases or when absolutley necessary. It does reduce the size of the binary from 30MB to less than 10MB
 

--- a/Dockerfile.epp
+++ b/Dockerfile.epp
@@ -2,7 +2,7 @@
 # Multi-stage build to keep the final image small
 
 # Stage 1: Build the EPP server binary
-FROM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 WORKDIR /build
 
@@ -23,14 +23,14 @@ COPY internal/ ./internal/
 # CGO is disabled for a fully static binary
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s -extldflags '-static' \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
     -a \
     -o epp-server \
     ./cmd/epp

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -5,7 +5,7 @@
 # allowing AI models and MCP clients to query registry state.
 
 # Stage 1: Build the MCP server binary
-FROM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 WORKDIR /build
 
@@ -27,14 +27,14 @@ COPY pkg/ ./pkg/
 # CGO is disabled for a fully static binary
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux go build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
     -o mcp-server \
     ./cmd/mcp
 

--- a/Dockerfile_Tilt
+++ b/Dockerfile_Tilt
@@ -52,11 +52,9 @@ RUN swag init -g ryAdminAPI.go -o /docs --parseDependency -d ./,/pkg/domain/enti
 WORKDIR /
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
 RUN go build -tags dynamic -ldflags="-s -w \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
       -o ryAdminAPI /cmd/api/ry-admin/ryAdminAPI.go
 # RUN upx --brute /ryAdminAPI # This takes a very long time to compress the binary we should only use if for official releases or when absolutley necessary. It does reduce the size of the binary from 30MB to less than 10MB
 

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,13 @@ BRANCH := $(shell git branch --show-current)
 TAG := $(subst /,-,$(BRANCH))
 GIT_SHA := $(shell git rev-parse HEAD)
 VERSION := $(shell cat VERSION)
-BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 DOPPLER := doppler run --
 DOCKER_COMPOSE := docker compose
 COMPOSE_FILE := docker-compose.yml
 COMPOSE_CI_FILE := docker-compose-ci.yml
 LDFLAGS := -s -w \
   -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=$(VERSION) \
-  -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=$(GIT_SHA) \
-  -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=$(BUILD_DATE)
+  -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=$(GIT_SHA)
 
 help: ## Show this help message
 	@echo 'Domain OS - Makefile Commands'
@@ -130,8 +128,7 @@ test-integration: ## [LEGACY FALLBACK] Run Postman/Newman integration tests (req
 	@echo "Building image for branch $(BRANCH) with commit $(GIT_SHA)..."
 	@docker build -t gprins/domain-os-api:$(TAG) \
 		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) .
+		--build-arg GIT_SHA=$(GIT_SHA) .
 	@echo "Starting integration test containers (will run Postman tests via Newman)..."
 	@export BRANCH=$(TAG) && COMPOSE_PROJECT_NAME=domain-os $(DOPPLER) \
 		$(DOCKER_COMPOSE) -p domain-os --profile essential -f $(COMPOSE_CI_FILE) \
@@ -288,29 +285,25 @@ build: ## Build the main API Docker image
 	@echo "Building API image for branch $(BRANCH) version $(VERSION)..."
 	@docker build -t gprins/domain-os-api:$(TAG) \
 		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) .
+		--build-arg GIT_SHA=$(GIT_SHA) .
 
 build-epp: ## Build the EPP server Docker image
 	@echo "Building EPP server image for branch $(BRANCH) version $(VERSION)..."
 	@docker build -t gprins/domain-os-epp:$(TAG) -f Dockerfile.epp \
 		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) .
+		--build-arg GIT_SHA=$(GIT_SHA) .
 
 build-whois: ## Build the WHOIS server Docker image
 	@echo "Building WHOIS server image for branch $(BRANCH) version $(VERSION)..."
 	@docker build -t gprins/domain-os-whois:$(TAG) -f ./cmd/whois/Dockerfile \
 		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) .
+		--build-arg GIT_SHA=$(GIT_SHA) .
 
 build-worker: ## Build the unified worker Docker image
 	@echo "Building Unified Worker image for branch $(BRANCH) version $(VERSION)..."
 	@docker build -t gprins/domain-os-worker:$(TAG) -f ./cmd/workers/unified/Dockerfile \
 		--build-arg VERSION=$(VERSION) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
-		--build-arg BUILD_DATE=$(BUILD_DATE) .
+		--build-arg GIT_SHA=$(GIT_SHA) .
 
 build-mcp: ## Build the MCP server Docker image
 	@echo "Building MCP server image for branch $(BRANCH)..."

--- a/cmd/api/ry-admin/ryAdminAPI.go
+++ b/cmd/api/ry-admin/ryAdminAPI.go
@@ -126,7 +126,7 @@ func main() {
 	// Load the APP configuration and log it
 	cfg := config.LoadConfig(buildinfo.GitSHA)
 	logger.Info("Starting Admin API with following config", zap.Any("config", cfg))
-	logger.Info("Build info", zap.String("version", buildinfo.Version), zap.String("git_sha", buildinfo.GitSHA), zap.String("build_date", buildinfo.BuildDate))
+	logger.Info("Build info", zap.String("version", buildinfo.Version), zap.String("git_sha", buildinfo.GitSHA))
 
 	// Check for init-registrars command
 	if len(os.Args) > 1 && os.Args[1] == "init-registrars" {

--- a/cmd/epp/eppServer.go
+++ b/cmd/epp/eppServer.go
@@ -57,7 +57,7 @@ func main() {
 		Level: logLevel,
 	}))
 
-	logger.Info("EPP server starting", "version", buildinfo.Version, "git_sha", buildinfo.GitSHA, "build_date", buildinfo.BuildDate)
+	logger.Info("EPP server starting", "version", buildinfo.Version, "git_sha", buildinfo.GitSHA)
 
 	// Initialize Redis client
 	redisHost := os.Getenv("REDIS_HOST")

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -33,7 +33,7 @@ func run() int {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	slog.SetDefault(logger)
 
-	logger.Info("MCP server build info", "version", buildinfo.Version, "git_sha", buildinfo.GitSHA, "build_date", buildinfo.BuildDate)
+	logger.Info("MCP server build info", "version", buildinfo.Version, "git_sha", buildinfo.GitSHA)
 
 	// Set up context with signal handling for graceful shutdown.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/whois/Dockerfile
+++ b/cmd/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS build
 
 WORKDIR /
 ENV CGO_ENABLED=0
@@ -20,13 +20,13 @@ COPY ./cmd/whois/ ./cmd/whois/
 FROM build AS build-whois
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    go build -tags dynamic -ldflags="-s -w \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags dynamic -ldflags="-s -w \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
       -o whoisServer /cmd/whois/whois.go
 
 # Create API release image

--- a/cmd/whois/whois.go
+++ b/cmd/whois/whois.go
@@ -26,7 +26,7 @@ const (
 )
 
 func main() {
-	log.Printf("whois-server version=%s sha=%s built=%s", buildinfo.Version, buildinfo.GitSHA, buildinfo.BuildDate)
+	log.Printf("whois-server version=%s sha=%s", buildinfo.Version, buildinfo.GitSHA)
 	// Set up a context to handle signals for graceful shutdown.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/cmd/workers/unified/Dockerfile
+++ b/cmd/workers/unified/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 WORKDIR /app
 # Leverage layer caching: download deps first
 COPY go.mod go.sum ./
@@ -9,13 +9,13 @@ COPY . .
 ENV GOTOOLCHAIN=auto
 ARG VERSION=dev
 ARG GIT_SHA=unknown
-ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 go build -ldflags="-s -w \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w \
       -X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=${VERSION} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA} \
-      -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=${BUILD_DATE}" \
+      -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=${GIT_SHA}" \
       -o /out/unified-worker ./cmd/workers/unified
 
 FROM alpine:3.21.4

--- a/cmd/workers/unified/main.go
+++ b/cmd/workers/unified/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	log.Printf("unified-worker version=%s sha=%s built=%s", buildinfo.Version, buildinfo.GitSHA, buildinfo.BuildDate)
+	log.Printf("unified-worker version=%s sha=%s", buildinfo.Version, buildinfo.GitSHA)
 	// Create a shared Temporal client
 	cfg := temporal.NewClientConfigFromEnv("")
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,12 +1,11 @@
 // Package buildinfo holds build-time metadata injected via -ldflags.
 // All binaries in the domain-os monorepo import this package to expose
-// a consistent version, git SHA, and build timestamp.
+// a consistent version and git SHA.
 //
 // Example ldflags:
 //
 //	go build -ldflags="-X github.com/onasunnymorning/domain-os/internal/buildinfo.Version=0.7.0 \
-//	  -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=abc123 \
-//	  -X github.com/onasunnymorning/domain-os/internal/buildinfo.BuildDate=2025-04-12T00:00:00Z"
+//	  -X github.com/onasunnymorning/domain-os/internal/buildinfo.GitSHA=abc123"
 package buildinfo
 
 // Version is the semantic version set at build time (e.g., "0.7.0").
@@ -15,6 +14,3 @@ var Version = "dev"
 
 // GitSHA is the full git commit hash set at build time.
 var GitSHA = "unknown"
-
-// BuildDate is the UTC ISO 8601 timestamp of when the binary was built.
-var BuildDate = "unknown"

--- a/internal/interface/rest/ping_controller.go
+++ b/internal/interface/rest/ping_controller.go
@@ -21,9 +21,8 @@ func NewPingController(e *gin.Engine) *PingController {
 // Ping is the handler for the ping endpoint
 func (ctrl *PingController) Ping(ctx *gin.Context) {
 	ctx.JSON(200, gin.H{
-		"message":    "pong",
-		"version":    buildinfo.Version,
-		"git_sha":    buildinfo.GitSHA,
-		"build_date": buildinfo.BuildDate,
+		"message": "pong",
+		"version": buildinfo.Version,
+		"git_sha": buildinfo.GitSHA,
 	})
 }


### PR DESCRIPTION
The multi-arch build compiled the arm64 leg under QEMU emulation (5-10x slower). Go cross-compiles natively, so pin each Go builder to the native build platform and target the arch via GOOS/GOARCH:

  FROM --platform=$BUILDPLATFORM golang:... AS builder
  ... GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ...

Applied to all five Go images (api, worker, epp, whois, mcp). Verified locally: from an arm64 host, the amd64 image gets an x86-64 binary and the arm64 image gets an aarch64 binary.

This also fixes a latent correctness bug: Dockerfile.epp hardcoded GOARCH=amd64, so its arm64 image variant shipped an x86-64 binary that would fail to exec on Graviton. It now honors $TARGETARCH.

Separately, drop BUILD_DATE entirely. Sourced from wall-clock `date`, it changed every run and could never be cached — even re-running the same commit forced a full recompile — and it broke build reproducibility, which undercuts the promote-by-digest release flow. GIT_SHA (constant per commit, genuinely useful) is kept. Removed the build-arg from all Dockerfiles, ci.yaml, and the Makefile, plus the buildinfo.BuildDate field, its five startup-log call sites, and the /ping build_date field (nothing consumes it: not the frontend, not tests, and the health check only checks status).