### PR TITLE
fix(db): escape credentials when building the postgres DSN

### DIFF
--- a/internal/infrastructure/db/postgres/connection.go
+++ b/internal/infrastructure/db/postgres/connection.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 
 	_ "github.com/lib/pq"     // Standard postgres driver (in case we need to create the database)
@@ -121,8 +122,25 @@ type Config struct {
 	AutoMigrate bool
 }
 
+// buildDSN assembles a postgres connection URL from cfg. It uses net/url so
+// credentials containing URL-reserved characters (:, @, /, ?, #, space, …) —
+// which RDS- and Secrets Manager-generated passwords routinely include — are
+// percent-escaped rather than corrupting the URL. Interpolating cfg.Pass raw
+// makes the parser read the password bytes as the host/port and fail with
+// "invalid port ... after host", panicking every deployment on startup.
+func buildDSN(cfg Config) string {
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(cfg.User, cfg.Pass),
+		Host:     fmt.Sprintf("%s:%s", cfg.Host, cfg.Port),
+		Path:     "/" + cfg.DBName,
+		RawQuery: "sslmode=" + url.QueryEscape(cfg.SSLmode),
+	}
+	return u.String()
+}
+
 func NewConnection(cfg Config) (*gorm.DB, error) {
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", cfg.User, cfg.Pass, cfg.Host, cfg.Port, cfg.DBName, cfg.SSLmode)
+	dsn := buildDSN(cfg)
 	gormDB, err := gorm.Open(postgres.Open(dsn))
 	if err != nil {
 		errMsg := err.Error()

--- a/internal/infrastructure/db/postgres/connection_dsn_test.go
+++ b/internal/infrastructure/db/postgres/connection_dsn_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"net/url"
+	"testing"
+)
+
+// TestBuildDSN_EscapesReservedCharacters guards against the runtime bug where a
+// database password containing URL-reserved characters (routine in RDS- and
+// Secrets Manager-generated credentials) was interpolated raw into a
+// postgres:// URL, so the password bled into the host:port and connection
+// setup panicked on startup with "invalid port ... after host".
+func TestBuildDSN_EscapesReservedCharacters(t *testing.T) {
+	cfg := Config{
+		User:    "alpaca_admin",
+		Pass:    `p@ss:w/rd?#`,
+		Host:    "db.internal.example.com",
+		Port:    "5432",
+		DBName:  "alpaca",
+		SSLmode: "require",
+	}
+
+	dsn := buildDSN(cfg)
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("buildDSN produced an unparseable URL %q: %v", dsn, err)
+	}
+	if got := u.Port(); got != cfg.Port {
+		t.Errorf("port = %q, want %q — the password likely bled into host:port", got, cfg.Port)
+	}
+	if got := u.Hostname(); got != cfg.Host {
+		t.Errorf("host = %q, want %q", got, cfg.Host)
+	}
+	if got := u.User.Username(); got != cfg.User {
+		t.Errorf("user = %q, want %q", got, cfg.User)
+	}
+	gotPass, _ := u.User.Password()
+	if gotPass != cfg.Pass {
+		t.Errorf("password round-trip = %q, want %q", gotPass, cfg.Pass)
+	}
+	if got := u.Query().Get("sslmode"); got != cfg.SSLmode {
+		t.Errorf("sslmode = %q, want %q", got, cfg.SSLmode)
+	}
+}


### PR DESCRIPTION
NewConnection interpolated cfg.Pass raw into a postgres:// URL. RDS- and Secrets Manager-generated passwords routinely contain URL-reserved characters (:, @, /, ?, #), so the parser read the password bytes as the host/port and panicked on startup:

  invalid port ":-<*lMrT!jQNdsIwa5hN!TyzZ<" after host

This blocked every deployment with a generated DB password — the app read all DB_* vars correctly, then died building the connection string.

Extract buildDSN and assemble the URL with net/url (url.UserPassword + url.URL), which percent-escapes the credentials. Unlike the key-value form, this is also safe for spaces and quotes. Add TestBuildDSN_EscapesReserved Characters, which parses the DSN for a password of "p@ss:w/rd?#" and asserts the port, host, and password round-trip — it fails against the old code with the exact "invalid port" error and passes now.