### PR TITLE
ci: build and publish images only at release, not on every main push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,22 +146,30 @@ jobs:
           cd frontend
           npm audit --audit-level=high
 
-  # Single source of truth for the image list. Both build-images and retag
-  # consume this, and internal/config.TestCIImageMatrixMatchesContract asserts
+  # Single source of truth for the image list, shared with the release build in
+  # release-please.yaml. internal/config.TestCIImageMatrixMatchesContract asserts
   # it lists exactly the images declared in the deployment contract.
+  #
+  # Images are built here for validation only, and only on real feature PRs:
+  # main pushes run tests only (nothing is published until a release), and
+  # release-please's version-bump PRs change no source, so there is nothing to
+  # rebuild.
   setup:
     name: Compute image matrix
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
     outputs:
       images: ${{ steps.matrix.outputs.images }}
-      names: ${{ steps.matrix.outputs.names }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
         run: |
           echo "images=$(jq -c . .github/images.json)" >> "$GITHUB_OUTPUT"
-          echo "names=$(jq -c '[.[].name]' .github/images.json)" >> "$GITHUB_OUTPUT"
 
+  # Validate that every image still builds and is CVE-clean before merge.
+  # amd64-only, loaded locally, never pushed — publishing happens only at
+  # release time (release-please.yaml). No Docker Hub login needed: base images
+  # are public and nothing is pushed, so fork PRs pass too.
   build-images:
     name: Build ${{ matrix.image.name }}
     runs-on: ubuntu-latest
@@ -173,59 +181,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # full history + tags so `git describe` can resolve the version
-      - name: Set up QEMU
-        if: github.ref == 'refs/heads/main'
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      # Only authenticate when we actually push (main). PRs — including from
-      # forks without access to secrets — build, load locally, and scan.
-      - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # Determine platforms: multi-platform on main, amd64-only on PRs for speed
-      - name: Set platforms
-        id: platforms
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
-          else
-            echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Version is derived from the git tag (release-please owns tags), not a
-      # committed file. On a tagged commit this is e.g. 0.8.0; between releases
-      # it is 0.8.0-<n>-g<sha>; with no tags it falls back to the short sha.
-      - name: Read version
-        id: version
-        run: |
-          echo "version=$(git describe --tags --always | sed 's/^v//')" >> "$GITHUB_OUTPUT"
-
-      # Push :<sha> only on main. On PRs, load the (single-arch) image into the
-      # local daemon so the Trivy step below can scan it without a registry push.
-      - name: Build
+      - name: Build (validation only — loaded, not pushed)
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.file }}
-          platforms: ${{ steps.platforms.outputs.platforms }}
-          push: ${{ github.ref == 'refs/heads/main' }}
-          load: ${{ github.ref != 'refs/heads/main' }}
+          platforms: linux/amd64
+          push: false
+          load: true
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=pr-${{ github.sha }}
             GIT_SHA=${{ github.sha }}
           tags: gprins/${{ matrix.image.name }}:${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 
-      # Gate the build on image CVEs. On main the image is pulled from the
-      # registry (authenticated above); on PRs it is the locally loaded image.
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
@@ -292,30 +264,3 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-  # :latest tracks the newest successful main build (a retag of the :<sha>
-  # digest — never a rebuild). Immutable :<version> tags are applied separately
-  # by the promote job in release-please.yaml when a release is cut.
-  retag:
-    name: Retag images as latest
-    runs-on: ubuntu-latest
-    needs: [setup, build-images, api-tests]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Install crane
-        run: |
-          VERSION=0.20.2
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar -xz crane
-          chmod +x crane
-
-      - name: Retag all images as latest
-        run: |
-          for img in $(echo '${{ needs.setup.outputs.names }}' | jq -r '.[]'); do
-            echo "Retagging gprins/${img}:${{ github.sha }} → :latest"
-            ./crane tag "gprins/${img}:${{ github.sha }}" latest
-          done

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,7 +14,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       version: ${{ steps.release.outputs.version }}
-      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -23,56 +22,65 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Promote by digest: when a release is cut, retag the exact :<sha> images that
-  # CI already built and scanned for the released commit as immutable :<version>
-  # tags. Nothing is rebuilt, so the released artifact is bit-for-bit what main
-  # tested. CI (ci.yaml) runs in parallel on the same push, so we wait for the
-  # :<sha> images to appear before tagging.
-  promote:
-    name: Promote release images
-    runs-on: ubuntu-latest
+  # Compute the image matrix from the same single source ci.yaml uses.
+  matrix:
     needs: [release-please]
     if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.m.outputs.images }}
     steps:
       - uses: actions/checkout@v4
+      - id: m
+        run: echo "images=$(jq -c . .github/images.json)" >> "$GITHUB_OUTPUT"
 
+  # The only place images are published. When a release is cut, build every
+  # image once — multi-arch — and push it as :<version> and :latest, then scan.
+  # Main merges build nothing; this is the release artifact.
+  release-build:
+    name: Release ${{ matrix.image.name }}
+    needs: [release-please, matrix]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.matrix.outputs.images) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install crane
-        run: |
-          VERSION=0.20.2
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/v${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar -xz crane
-          chmod +x crane
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.file }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ needs.release-please.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            gprins/${{ matrix.image.name }}:${{ needs.release-please.outputs.version }}
+            gprins/${{ matrix.image.name }}:latest
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 
-      - name: Wait for CI images, then promote to :${{ needs.release-please.outputs.version }}
-        env:
-          SHA: ${{ needs.release-please.outputs.sha }}
-          VERSION: ${{ needs.release-please.outputs.version }}
-        run: |
-          names=$(jq -r '.[].name' .github/images.json)
-
-          # CI builds :<sha> in a parallel workflow; wait up to 30 min for each.
-          for img in $names; do
-            echo "Waiting for gprins/${img}:${SHA} ..."
-            found=""
-            for _ in $(seq 1 60); do
-              if ./crane manifest "gprins/${img}:${SHA}" >/dev/null 2>&1; then
-                found=1; echo "  found"; break
-              fi
-              sleep 30
-            done
-            if [ -z "$found" ]; then
-              echo "::error::timed out waiting for gprins/${img}:${SHA} — is the CI build for this commit green?"
-              exit 1
-            fi
-          done
-
-          # Retag the digest — no rebuild.
-          for img in $names; do
-            echo "Promoting gprins/${img}:${SHA} → :${VERSION}"
-            ./crane tag "gprins/${img}:${SHA}" "${VERSION}"
-          done
+      # Backstop CVE gate. PRs already scan pre-merge, so a failure here means a
+      # base image drifted between merge and release — fix forward with a patch.
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: gprins/${{ matrix.image.name }}:${{ needs.release-please.outputs.version }}
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -2,64 +2,75 @@
 
 How container images are built, scanned, published, and released.
 
-## The model: build once on main, promote by digest
+## The model: build the release, deploy versions
 
-Every push to `main` builds each service image, scans it, and publishes it to
-Docker Hub under an **immutable `:<sha>` tag**. That image is the artifact — it
-is what the tests ran against and what deployments should pin.
+We deploy tagged **releases**, not individual commits, so images are built and
+published exactly once — when a release is cut. Between releases, `main` merges
+run tests only and publish nothing.
 
-When a release is cut, nothing is rebuilt. The exact `:<sha>` image that `main`
-already built and scanned is **retagged** to `:<version>`. Docker builds are not
-reproducible (base images move, `npm ci` and `go mod` resolve against live
-registries), so rebuilding at release time would ship bits that were never
-tested. Retagging a digest makes that impossible and is also far faster.
+- **Pull requests** run the full test suite and build every image (amd64) to
+  prove it still builds and is CVE-clean. These images are loaded locally and
+  scanned, never pushed.
+- **Pushes to `main`** run tests only.
+- **Releases** (cut by release-please) build every image multi-arch, push
+  `:<version>` and `:latest`, and scan.
 
 | Tag | Meaning | Mutable? | Set by |
 | --- | --- | --- | --- |
-| `:<sha>` | Exactly what CI built for that commit | No | `ci.yaml` (main only) |
-| `:latest` | Newest successful `main` build | Yes | `ci.yaml` `retag` job |
-| `:<version>` (e.g. `0.7.1`) | A cut release | No | `release-please.yaml` `promote` job |
+| `:<version>` (e.g. `0.8.1`) | An immutable release | No | `release-please.yaml` → `release-build` |
+| `:latest` | The most recent release | Yes | same |
 
-Deployments should pin `:<sha>` or `:<version>`, never `:latest`.
+Deployments pin `:<version>`, or use `:latest` to track the current release.
+
+This replaced an earlier "build on every `main` push, promote the digest at
+release" model. That guarantees every commit is a deployable artifact, but when
+the deploy unit is the release it just means building the same code two or three
+times per release cycle — so we build the thing we actually ship, once.
 
 ## Images
 
 The image list is defined once in [`.github/images.json`](../.github/images.json)
-and consumed by every workflow that needs it. `internal/config`'s
-`TestCIImageMatrixMatchesContract` (run by the `envcheck` CI job) asserts this
-file lists exactly the services in the [deployment contract](../deploy/contract.json),
+and shared by `ci.yaml` and the release build. `internal/config`'s
+`TestCIImageMatrixMatchesContract` (run by the `envcheck` job) asserts this file
+lists exactly the services in the [deployment contract](../deploy/contract.json),
 so a service can never be added to the contract but forgotten in the pipeline.
 
 All six images publish under the `gprins/` Docker Hub namespace, each named
 `domain-os-<role>`: `domain-os-api`, `domain-os-worker`, `domain-os-epp`,
 `domain-os-whois`, `domain-os-mcp`, `domain-os-frontend`.
 
+## Version
+
+The version comes from the git tag (release-please owns tags) via
+`git describe`, not a committed file — see the README's *Versioning* section. CI
+stamps it into each binary (build-arg → `buildinfo.Version`, surfaced at
+`/ping`), and the release build tags the images with it.
+
 ## Workflows
 
-### `ci.yaml` — on every push to `main` and every PR
+### `ci.yaml` — every PR and every push to `main`
 
-- **Tests & checks**: secret scan, lint, env/contract drift, Go unit tests, Go
-  API integration tests, frontend tests.
-- **`build-images`** (matrix over `images.json`): builds each image and runs a
-  Trivy scan gated on `CRITICAL`/`HIGH`.
-  - On `main`: multi-arch (`amd64`+`arm64`), pushed as `:<sha>`.
-  - On PRs: `amd64`-only, **not pushed** — loaded locally and scanned, so PRs
-    never write to the registry and fork PRs without secrets still pass.
-- **`retag`** (main only): retags each `:<sha>` as `:latest`.
+- **Tests & checks** (both PRs and `main`): secret scan, lint, env/contract
+  drift, Go unit + API integration tests, frontend tests.
+- **`build-images`** (feature PRs only): builds each image `amd64`, loads it
+  locally, and Trivy-scans (`CRITICAL`/`HIGH`). Never pushes — no Docker Hub
+  login required, so fork PRs pass. Skipped on `main` pushes (tests only) and on
+  release-please's version-bump PRs (no source changes to validate).
 
-### `release-please.yaml` — on push to `main`
+### `release-please.yaml` — push to `main`
 
 - **`release-please`**: maintains the release PR; on merge, creates the GitHub
   release, tag, and changelog, and bumps the version.
-- **`promote`** (only when a release was created): waits for the release
-  commit's `:<sha>` images (CI builds them in parallel) and retags each to
-  `:<version>`. No rebuild.
+- **`release-build`** (only when a release is created): builds every image
+  multi-arch (`amd64`+`arm64`), pushes `:<version>` and `:latest`, and scans.
+  This is the only place images are published.
 
 ### `trivy-scheduled.yaml` — Mondays 06:00 UTC (and manual)
 
-Non-blocking (`exit-code: 0`) Trivy scan of every `:latest` image, so base-image
-CVE drift surfaces on a schedule instead of ambushing an unrelated PR. Fixing a
-finding means bumping a base image (or adding `apk upgrade`) via a normal PR.
+Non-blocking (`exit-code: 0`) Trivy scan of every `:latest` image (= the latest
+release), so base-image CVE drift surfaces on a schedule instead of ambushing a
+release. Fixing a finding means bumping a base image (or adding `apk upgrade`)
+via a normal PR.
 
 ## Required GitHub configuration
 
@@ -67,7 +78,7 @@ Set these on the repository (Settings → Secrets and variables → Actions):
 
 | Name | Kind | Value | Used by |
 | --- | --- | --- | --- |
-| `DOCKERHUB_USERNAME` | **Variable** | `gprins` | Docker Hub login (push/retag/promote/scan) |
+| `DOCKERHUB_USERNAME` | **Variable** | `gprins` | Docker Hub login for the release build |
 | `DOCKERHUB_TOKEN` | **Secret** | Docker Hub access token | same |
 | `GITHUB_TOKEN` | Automatic | — | secret scan, release-please (injected by Actions) |
 
@@ -75,6 +86,7 @@ Set these on the repository (Settings → Secrets and variables → Actions):
 repository **variable** (`vars.`) — it shows up unmasked in logs, which makes a
 failed push readable. Only `DOCKERHUB_TOKEN` is a secret. No `GITLEAKS_LICENSE`
 is needed because the repo is under a personal account, not an organization.
+Pull requests need neither — they build and scan without pushing.
 
 ### Rotating the Docker Hub token
 
@@ -83,10 +95,10 @@ is needed because the repo is under a personal account, not an organization.
 2. Update the `DOCKERHUB_TOKEN` repository secret.
 3. Revoke the old token.
 
-## Why release promotion lives in `release-please.yaml`
+## Why the release build lives in `release-please.yaml`
 
 A separate workflow triggered by the release tag would never fire: GitHub does
 not trigger workflow runs from events created by the default `GITHUB_TOKEN`, and
-release-please creates its tag with that token. Running `promote` as a job in
-the same workflow as the release-please action sidesteps this entirely — no PAT,
-no second workflow, no cross-workflow event to break.
+release-please creates its tag with that token. Running `release-build` as a job
+in the same workflow as the release-please action sidesteps this entirely — no
+PAT, no second workflow, no cross-workflow event to break.


### PR DESCRIPTION
We deploy tagged releases, not individual commits, so building and pushing all six images on every main merge — then again on the release-PR merge — meant building the same code two or three times per release. Switch to building the release artifact once, when a release is cut.

- ci.yaml: image build+scan is now PR-validation only (amd64, loaded, never pushed), and skips main pushes (tests only) and release-please's version-bump PRs (no source to validate). Drop the retag job; :latest is set at release now. No Docker Hub login on PRs — fork PRs pass.
- release-please.yaml: replace the promote/wait-loop with a release-build job that builds every image multi-arch, pushes :<version> + :latest, and scans — the single publish point. No more promote-by-digest (there are no :<sha> images to promote when main doesn't build them).
- docs/ci-cd.md: document the release-only model and the new tag semantics.

Per feature->release this cuts image builds from three (main merge, release PR, release merge) to one (at release), and makes main merges tests-only.