### PR TITLE
refactor(repository): accept domain FX entities

### DIFF
--- a/internal/application/activities/fxActivities.go
+++ b/internal/application/activities/fxActivities.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/onasunnymorning/domain-os/internal/infrastructure/api/frankfurter"
 	postgres "github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
+	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"go.temporal.io/sdk/activity"
 	"gorm.io/gorm"
 )
@@ -19,7 +20,7 @@ type FXRatesSource interface {
 
 // fxStore is the subset of the FX repository the activities need.
 type fxStore interface {
-	UpdateAll(ctx context.Context, fxs []*postgres.FX) error
+	UpdateAll(ctx context.Context, fxs []*entities.FX) error
 }
 
 // baseCurrencyLister provides the distinct base currencies configured across phases.
@@ -126,7 +127,7 @@ func (a *FXActivities) UpdateFXRates(ctx context.Context, correlationID string, 
 			continue
 		}
 
-		fxs := make([]*postgres.FX, 0, len(rates))
+		fxs := make([]*entities.FX, 0, len(rates))
 		conversionFailed := false
 		for _, r := range rates {
 			date, err := r.ParsedDate()
@@ -135,11 +136,11 @@ func (a *FXActivities) UpdateFXRates(ctx context.Context, correlationID string, 
 				conversionFailed = true
 				break
 			}
-			fxs = append(fxs, &postgres.FX{
-				Date:   date,
-				Base:   r.Base,
-				Target: r.Quote,
-				Rate:   r.Rate,
+			fxs = append(fxs, &entities.FX{
+				Date:           date,
+				BaseCurrency:   r.Base,
+				TargetCurrency: r.Quote,
+				Rate:           r.Rate,
 			})
 		}
 		if conversionFailed {

--- a/internal/application/activities/fxActivities_test.go
+++ b/internal/application/activities/fxActivities_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/onasunnymorning/domain-os/internal/infrastructure/api/frankfurter"
-	postgres "github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
+	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 
 type mockFXStore struct{ mock.Mock }
 
-func (m *mockFXStore) UpdateAll(ctx context.Context, fxs []*postgres.FX) error {
+func (m *mockFXStore) UpdateAll(ctx context.Context, fxs []*entities.FX) error {
 	return m.Called(ctx, fxs).Error(0)
 }
 
@@ -57,7 +57,7 @@ func TestUpdateFXRates_ExplicitBases_Success(t *testing.T) {
 
 	rates.On("GetLatestRates", mock.Anything, "USD", []string(nil)).Return(testRates("USD"), nil)
 	rates.On("GetLatestRates", mock.Anything, "EUR", []string(nil)).Return(testRates("EUR"), nil)
-	store.On("UpdateAll", mock.Anything, mock.AnythingOfType("[]*postgres.FX")).Return(nil)
+	store.On("UpdateAll", mock.Anything, mock.AnythingOfType("[]*entities.FX")).Return(nil)
 
 	result, err := a.UpdateFXRates(context.Background(), "corr", []string{"USD", "EUR"})
 	require.NoError(t, err)

--- a/internal/application/services/domain_service_batch_mocks_test.go
+++ b/internal/application/services/domain_service_batch_mocks_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/onasunnymorning/domain-os/internal/application/queries"
-	"github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
 	"github.com/onasunnymorning/domain-os/internal/infrastructure/snowflakeidgenerator"
 	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"github.com/onasunnymorning/domain-os/pkg/domain/repositories"
@@ -197,7 +196,7 @@ type mockFXRepository struct {
 	mock.Mock
 }
 
-func (m *mockFXRepository) UpdateAll(ctx context.Context, fxs []*postgres.FX) error {
+func (m *mockFXRepository) UpdateAll(ctx context.Context, fxs []*entities.FX) error {
 	return m.Called(ctx, fxs).Error(0)
 }
 

--- a/internal/application/services/sync_service.go
+++ b/internal/application/services/sync_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/onasunnymorning/domain-os/internal/infrastructure/api/frankfurter"
-	"github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
+	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"github.com/onasunnymorning/domain-os/pkg/domain/repositories"
 )
 
@@ -106,19 +106,19 @@ func (s *SyncService) RefreshFXRates(ctx context.Context, baseCurrency string) e
 	return s.FXRepository.UpdateAll(ctx, fxs)
 }
 
-// frankfurterRatesToFX converts Frankfurter API rates to FX database records.
-func frankfurterRatesToFX(rates []frankfurter.Rate) ([]*postgres.FX, error) {
-	fxs := make([]*postgres.FX, 0, len(rates))
+// frankfurterRatesToFX converts Frankfurter API rates to domain FX entities.
+func frankfurterRatesToFX(rates []frankfurter.Rate) ([]*entities.FX, error) {
+	fxs := make([]*entities.FX, 0, len(rates))
 	for _, r := range rates {
 		date, err := r.ParsedDate()
 		if err != nil {
 			return nil, fmt.Errorf("invalid rate date %q for %s/%s: %w", r.Date, r.Base, r.Quote, err)
 		}
-		fxs = append(fxs, &postgres.FX{
-			Date:   date,
-			Base:   r.Base,
-			Target: r.Quote,
-			Rate:   r.Rate,
+		fxs = append(fxs, &entities.FX{
+			Date:           date,
+			BaseCurrency:   r.Base,
+			TargetCurrency: r.Quote,
+			Rate:           r.Rate,
 		})
 	}
 	return fxs, nil

--- a/internal/application/services/sync_service_fx_test.go
+++ b/internal/application/services/sync_service_fx_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/onasunnymorning/domain-os/internal/infrastructure/api/frankfurter"
-	"github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
+	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -40,17 +40,17 @@ func TestRefreshFXRates_Success(t *testing.T) {
 		{Date: "2026-07-17", Base: "USD", Quote: "PEN", Rate: 3.3903},
 	}, nil)
 
-	var stored []*postgres.FX
-	fxRepo.On("UpdateAll", mock.Anything, mock.AnythingOfType("[]*postgres.FX")).
-		Run(func(args mock.Arguments) { stored = args.Get(1).([]*postgres.FX) }).
+	var stored []*entities.FX
+	fxRepo.On("UpdateAll", mock.Anything, mock.AnythingOfType("[]*entities.FX")).
+		Run(func(args mock.Arguments) { stored = args.Get(1).([]*entities.FX) }).
 		Return(nil)
 
 	err := svc.RefreshFXRates(context.Background(), "USD")
 	require.NoError(t, err)
 
 	require.Len(t, stored, 2)
-	assert.Equal(t, "USD", stored[0].Base)
-	assert.Equal(t, "EUR", stored[0].Target)
+	assert.Equal(t, "USD", stored[0].BaseCurrency)
+	assert.Equal(t, "EUR", stored[0].TargetCurrency)
 	assert.Equal(t, 0.87209, stored[0].Rate)
 	assert.Equal(t, time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC), stored[0].Date)
 }

--- a/internal/infrastructure/db/postgres/fx_repository.go
+++ b/internal/infrastructure/db/postgres/fx_repository.go
@@ -23,17 +23,22 @@ func NewFXRepository(db *gorm.DB) *FXRepository {
 // rates in a single transaction. Running delete + insert atomically ensures a
 // failure can never leave the base currency without any rates (which would
 // make every quote in a non-base currency fail until the next sync).
-func (r *FXRepository) UpdateAll(ctx context.Context, fxs []*FX) error {
+func (r *FXRepository) UpdateAll(ctx context.Context, fxs []*entities.FX) error {
 	if len(fxs) == 0 {
 		return nil
 	}
+	dbFXs := make([]*FX, len(fxs))
+	for i, fx := range fxs {
+		dbFXs[i] = &FX{}
+		dbFXs[i].FromEntity(fx)
+	}
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Drop all records from the fx table for the given base currency
-		if err := tx.Where("base = ?", fxs[0].Base).Delete(&FX{}).Error; err != nil {
+		if err := tx.Where("base = ?", fxs[0].BaseCurrency).Delete(&FX{}).Error; err != nil {
 			return err
 		}
 		// Insert the new records
-		return tx.Create(&fxs).Error
+		return tx.Create(&dbFXs).Error
 	})
 }
 

--- a/internal/infrastructure/db/postgres/fx_repository_test.go
+++ b/internal/infrastructure/db/postgres/fx_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 )
@@ -28,24 +29,24 @@ func (s *FXSuite) TearDownSuite() {
 func (s *FXSuite) TestFX_UpdateAll() {
 	testTimeString := "2021-01-01T00:00:00Z"
 	testTime, _ := time.Parse(time.RFC3339, testTimeString)
-	fxs := []*FX{
+	fxs := []*entities.FX{
 		{
-			Date:   testTime,
-			Base:   "USD",
-			Target: "EUR",
-			Rate:   1.5,
+			Date:           testTime,
+			BaseCurrency:   "USD",
+			TargetCurrency: "EUR",
+			Rate:           1.5,
 		},
 		{
-			Date:   testTime,
-			Base:   "USD",
-			Target: "JPY",
-			Rate:   100.0,
+			Date:           testTime,
+			BaseCurrency:   "USD",
+			TargetCurrency: "JPY",
+			Rate:           100.0,
 		},
 		{
-			Date:   testTime,
-			Base:   "USD",
-			Target: "PEN",
-			Rate:   3.72312,
+			Date:           testTime,
+			BaseCurrency:   "USD",
+			TargetCurrency: "PEN",
+			Rate:           3.72312,
 		},
 	}
 
@@ -74,16 +75,16 @@ func (s *FXSuite) TestFX_UpdateAll_ReplacesOnlyGivenBase() {
 	day1, _ := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
 	day2, _ := time.Parse(time.RFC3339, "2026-01-02T00:00:00Z")
 
-	s.Require().NoError(repo.UpdateAll(context.Background(), []*FX{
-		{Date: day1, Base: "GBP", Target: "EUR", Rate: 1.2},
+	s.Require().NoError(repo.UpdateAll(context.Background(), []*entities.FX{
+		{Date: day1, BaseCurrency: "GBP", TargetCurrency: "EUR", Rate: 1.2},
 	}))
-	s.Require().NoError(repo.UpdateAll(context.Background(), []*FX{
-		{Date: day1, Base: "CAD", Target: "EUR", Rate: 0.7},
+	s.Require().NoError(repo.UpdateAll(context.Background(), []*entities.FX{
+		{Date: day1, BaseCurrency: "CAD", TargetCurrency: "EUR", Rate: 0.7},
 	}))
 
 	// Replacing GBP must not touch CAD
-	s.Require().NoError(repo.UpdateAll(context.Background(), []*FX{
-		{Date: day2, Base: "GBP", Target: "EUR", Rate: 1.25},
+	s.Require().NoError(repo.UpdateAll(context.Background(), []*entities.FX{
+		{Date: day2, BaseCurrency: "GBP", TargetCurrency: "EUR", Rate: 1.25},
 	}))
 
 	gbp, err := repo.ListByBaseCurrency(context.Background(), "GBP")
@@ -120,5 +121,5 @@ func (s *FXSuite) TestFX_GetByBaseAndTargetCurrency_ReturnsLatest() {
 // index-out-of-range panic risk on fxs[0]).
 func (s *FXSuite) TestFX_UpdateAll_EmptyInput() {
 	repo := NewFXRepository(s.db)
-	s.Require().NoError(repo.UpdateAll(context.Background(), []*FX{}))
+	s.Require().NoError(repo.UpdateAll(context.Background(), []*entities.FX{}))
 }

--- a/pkg/domain/repositories/fx_interface.go
+++ b/pkg/domain/repositories/fx_interface.go
@@ -3,13 +3,12 @@ package repositories
 import (
 	"context"
 
-	"github.com/onasunnymorning/domain-os/internal/infrastructure/db/postgres"
 	"github.com/onasunnymorning/domain-os/pkg/domain/entities"
 )
 
 // FXRepository is the interface for the FXRepository
 type FXRepository interface {
-	UpdateAll(ctx context.Context, fxs []*postgres.FX) error
+	UpdateAll(ctx context.Context, fxs []*entities.FX) error
 	ListByBaseCurrency(ctx context.Context, baseCurrency string) ([]*entities.FX, error)
 	GetByBaseAndTargetCurrency(ctx context.Context, baseCurrency, targetCurrency string) (*entities.FX, error)
 }


### PR DESCRIPTION
## Summary

- make the FX repository write contract accept domain `entities.FX` values
- convert domain values to Postgres models inside the GORM adapter
- update the sync service, Temporal activity, mocks, and repository tests to use the domain type

This removes the Postgres-model dependency from `fx_interface.go` while preserving the existing transactional replace behavior.

## Validation

- `go build ./...`
- `TEST_DB_PORT=5433 go test -race -count=1 ./...` (using the repository's SSL Postgres test setup)
- `go vet ./internal/application/services ./internal/application/activities ./internal/infrastructure/db/postgres ./pkg/domain/repositories`
- `git diff --check`

Closes #400
